### PR TITLE
Simplify unsLookup a little

### DIFF
--- a/src/Data/UnsafeMap.hs
+++ b/src/Data/UnsafeMap.hs
@@ -6,4 +6,4 @@ import Data.Maybe (fromMaybe)
 
 -- | Performs normal lookup in a map, but raises an error with supplied message.
 unsLookup :: Ord k => String -> k -> Map k v -> v
-unsLookup err k m = fromMaybe (error err) (Map.lookup k m)
+unsLookup err k m = Map.findWithDefault (error err) k m


### PR DESCRIPTION
[Map.findWithDefault](http://hackage.haskell.org/package/containers-0.5.6.3/docs/Data-Map-Lazy.html#v:findWithDefault) to the rescue

Actually, it can be simplified a bit further:

```
unsLookup = Map.findWithDefault . error
```
